### PR TITLE
feat(obz): improve OBZ creation with bug fixes and new features

### DIFF
--- a/app/api/board_builder/util/boards_to_obz.rb
+++ b/app/api/board_builder/util/boards_to_obz.rb
@@ -1,16 +1,28 @@
+require 'open-uri'
+require 'base64'
+
 module BoardBuilder
     module Util
         module BoardsToObz
           # Builds the OBZ file map: a hash of { filename => content } representing
           # all files that would be zipped into the .obz archive.
           #
+          # Options:
+          #   embed_images: [Boolean] (default: false)
+          #     When false (default): image entries carry a "url" pointing to the remote asset.
+          #     When true: each image is downloaded and stored in the file map under
+          #     "images/<image_id>.<ext>". The image entry uses "path" instead of "url",
+          #     and the manifest paths.images map is populated accordingly.
+          #     This produces a fully self-contained archive per the OBZ spec
+          #     (§"path-based referencing").
+          #
           # The spec requires:
           #   - Each board is a separate .obf file (JSON) stored at "boards/<id>"
-          #   - A manifest.json at the root maps all board paths
+          #   - A manifest.json at the root maps all board and image paths
           #   - manifest "root" points to the first (home) board path
           #   - All IDs must be strings (not integers)
           #   - load_board.path must point to the .obf path of the linked board
-          def self.boards_to_obz_file_map(boards)
+          def self.boards_to_obz_file_map(boards, embed_images: false)
             file_map        = {}
             gs_id_board_map = {}   # gs board.id  =>  obf board hash
             obf_id_path_map = {}   # obf board id =>  its path in the zip ("boards/xxx.obf")
@@ -40,7 +52,7 @@ module BoardBuilder
               }
             }
 
-            # Second pass: resolve load_board links and populate manifest paths
+            # Second pass: resolve load_board links, populate manifest, embed images if requested
             gs_id_board_map.each_value do |obf_board|
               obf_path = obf_id_path_map[obf_board["id"]]
               manifest["paths"]["boards"][obf_board["id"]] = obf_path
@@ -63,6 +75,28 @@ module BoardBuilder
                 else
                   # Linked board not exported in this package — drop the unresolvable link
                   button.delete("load_board")
+                end
+              end
+
+              # Optionally embed images: download each remote URL and store it as a file
+              # in the zip, replacing "url" with "path" on the image entry.
+              # Spec §"path-based referencing": images can be included in the zipped package
+              # and referenced using the path attribute.
+              if embed_images
+                obf_board["images"].each do |image|
+                  next if image["url"].blank?
+
+                  image_path, image_data = download_image(image["id"], image["url"])
+                  next if image_path.nil? || image_data.nil?
+
+                  # Store the raw binary in the file map under its zip path
+                  file_map[image_path]    = image_data
+                  # Register in manifest
+                  manifest["paths"]["images"][image["id"]] = image_path
+
+                  # Replace "url" with "path" on the image entry (spec priority: path > url)
+                  image["path"] = image_path
+                  image.delete("url")
                 end
               end
             end
@@ -142,6 +176,22 @@ module BoardBuilder
             obf
           end
 
+          # Downloads an image from a remote URL and returns [zip_path, binary_data].
+          # The zip path is "images/<image_id>.<ext>", where the extension is inferred
+          # from the URL or falls back to "png".
+          # Returns [nil, nil] on any network or HTTP error so callers can skip gracefully.
+          def self.download_image(image_id, url)
+            ext      = File.extname(URI.parse(url).path).delete_prefix(".").downcase
+            ext      = "png" if ext.blank? || ext.length > 5   # guard against garbage extensions
+            zip_path = "images/#{image_id}.#{ext}"
+
+            data = URI.open(url, read_timeout: 10, open_timeout: 5, &:read) # rubocop:disable Security/Open
+            [zip_path, data]
+          rescue StandardError => e
+            Rails.logger.warn "[BoardsToObz] Could not download image #{url}: #{e.message}"
+            [nil, nil]
+          end
+
           # ID generators
           # Spec: IDs must be strings and unique within the .obz package.
           # Combining a random hex segment with the GS record id guarantees both.
@@ -159,6 +209,7 @@ module BoardBuilder
           end
 
           private_class_method :transform_board_to_obf
+          private_class_method :download_image
           private_class_method :generate_board_id
           private_class_method :generate_button_id
           private_class_method :generate_image_id

--- a/app/api/board_builder/util/boards_to_obz.rb
+++ b/app/api/board_builder/util/boards_to_obz.rb
@@ -1,104 +1,167 @@
 module BoardBuilder
     module Util
         module BoardsToObz
-          def self.boards_to_obz_file_map (boards)
-            file_map = {}
-            gs_id_board_map = {}
-            first_obf_board = nil
+          # Builds the OBZ file map: a hash of { filename => content } representing
+          # all files that would be zipped into the .obz archive.
+          #
+          # The spec requires:
+          #   - Each board is a separate .obf file (JSON) stored at "boards/<id>"
+          #   - A manifest.json at the root maps all board paths
+          #   - manifest "root" points to the first (home) board path
+          #   - All IDs must be strings (not integers)
+          #   - load_board.path must point to the .obf path of the linked board
+          def self.boards_to_obz_file_map(boards)
+            file_map        = {}
+            gs_id_board_map = {}   # gs board.id  =>  obf board hash
+            obf_id_path_map = {}   # obf board id =>  its path in the zip ("boards/xxx.obf")
+            first_obf_path  = nil
 
+            # First pass: build every .obf board and register its zip path
             boards.each do |board|
               obf_board = transform_board_to_obf(board)
-              first_obf_board = first_obf_board || obf_board
-              gs_id_board_map[board.id] = obf_board
-              file_map[obf_board["id"]] = obf_board
+              obf_path  = "boards/#{obf_board["id"]}"   # e.g. "boards/board-abc123-42.obf"
+
+              first_obf_path = first_obf_path || obf_path
+
+              gs_id_board_map[board.id]        = obf_board
+              obf_id_path_map[obf_board["id"]] = obf_path
+              file_map[obf_path]               = obf_board
             end
 
+            # Build manifest.json
+            # Spec: manifest root = path to root board; paths.boards maps id => path
             manifest = {
               "format" => "open-board-0.1",
-              "root" => first_obf_board["id"],
-              "paths" => {
+              "root"   => first_obf_path,
+              "paths"  => {
                 "boards" => {},
                 "images" => {},
                 "sounds" => {}
               }
             }
 
+            # Second pass: resolve load_board links and populate manifest paths
             gs_id_board_map.each_value do |obf_board|
-              manifest["paths"]["boards"][obf_board["id"]] = obf_board["id"]
+              obf_path = obf_id_path_map[obf_board["id"]]
+              manifest["paths"]["boards"][obf_board["id"]] = obf_path
+
               obf_board["buttons"].each do |button|
-                if !button["load_board"].blank?
-                  linked_obf = gs_id_board_map[button["load_board"]["id"]]
-                  if !linked_obf.blank?
-                    button["load_board"]["id"] = linked_obf["id"]
-                    button["load_board"]["path"] = linked_obf["id"]
-                  else
-                    button.delete("load_board")
-                  end
+                next if button["load_board"].blank?
+
+                # load_board["id"] currently holds the GS integer board.id (set during
+                # transform_board_to_obf). Resolve it to the linked OBF board now.
+                linked_gs_id = button["load_board"]["id"]
+                linked_obf   = gs_id_board_map[linked_gs_id]
+
+                if linked_obf.present?
+                  linked_path = obf_id_path_map[linked_obf["id"]]
+                  # Spec: load_board must carry a string "id" and a "path" to the .obf
+                  button["load_board"] = {
+                    "id"   => linked_obf["id"],   # string OBF id, not the integer GS id
+                    "path" => linked_path
+                  }
+                else
+                  # Linked board not exported in this package — drop the unresolvable link
+                  button.delete("load_board")
                 end
               end
             end
+
             file_map["manifest.json"] = manifest
             file_map
           end
 
-          # converts a board from global symbols to obf format
-          # attention: load_board.id attribute is the actual id of the gs_board and
-          # has to be converted to the correct id/path afterwards
+          # Converts a GS board (ActiveRecord object) to an OBF hash.
+          #
+          # Spec compliance:
+          #   - All IDs are strings (spec §"Numerical IDs")
+          #   - Empty cell slots are null in grid.order (spec §"Button Ordering")
+          #   - Colors and labels only emitted when present (avoids null fields)
+          #   - locale sourced from the parent board_set
+          #
+          # ATTENTION: load_board["id"] stores the GS integer board id at this stage.
+          # It is resolved to a proper string OBF id by boards_to_obz_file_map.
           def self.transform_board_to_obf(gs_board)
-            obf_in_json = {
-              "format" => "open-board-0.1",
-              "id" => "#{generate_unique_id("board", gs_board.id)}.obf",
-              "name" => gs_board["name"],
+            rows    = gs_board["rows"].to_i
+            columns = gs_board["columns"].to_i
+
+            obf = {
+              "format"  => "open-board-0.1",
+              "id"      => "#{generate_board_id(gs_board.id)}.obf",
+              "name"    => gs_board["name"].to_s,
+              "locale"  => gs_board.board_set.lang.presence || "en",
               "buttons" => [],
-              "grid" => {
-                "rows" => gs_board["rows"],
-                "columns" => gs_board["columns"],
-                "order" => Array.new(gs_board["rows"]) { Array.new(gs_board["columns"]) }
+              "grid"    => {
+                "rows"    => rows,
+                "columns" => columns,
+                # All slots start as null; filled in below (spec: unused slots must be null)
+                "order"   => Array.new(rows) { Array.new(columns, nil) }
               },
-              "images" => []
+              "images"  => []
             }
 
-            cells = gs_board.cells.map(&:attributes)
+            # Sort cells by index for deterministic row/column positioning
+            cells = gs_board.cells.sort_by { |c| c.index || 0 }.map(&:attributes)
+
             cells.each_with_index do |cell, index|
-              button_id = generate_unique_id("button", cell["id"])
-              image_id = generate_unique_id("image", cell["id"])
+              row    = index / columns
+              column = index % columns
 
-              button = {
-                "id" => button_id,
-                "label" => cell["caption"],
-                "background_color" => cell["background_colour"]
-              }
+              # Skip cells that fall outside the declared grid dimensions
+              next unless row < rows && column < columns
 
-              if !cell["image_url"].blank?
+              button_id = generate_button_id(cell["id"])
+              button    = { "id" => button_id }
+
+              # Spec: label omitted when blank so parsers receive no empty string
+              button["label"] = cell["caption"] if cell["caption"].present?
+
+              # Colors only emitted when set (spec allows omitting unset attributes)
+              button["background_color"] = cell["background_colour"] if cell["background_colour"].present?
+              button["border_color"]     = cell["border_colour"]     if cell["border_colour"].present?
+
+              # Image reference: image_id on button + entry in images array
+              if cell["image_url"].present?
+                image_id = generate_image_id(cell["id"])
                 button["image_id"] = image_id
-                obf_in_json["images"] << {
-                  "id" => image_id,
+                obf["images"] << {
+                  "id"  => image_id,
                   "url" => cell["image_url"]
                 }
               end
 
-              if !cell["linked_to_boardbuilder_board_id"].blank?
-                button["load_board"] = {
-                  "id" => cell["linked_to_boardbuilder_board_id"]
-                }
+              # Board link — integer GS id, replaced with string OBF id in second pass
+              if cell["linked_to_boardbuilder_board_id"].present?
+                button["load_board"] = { "id" => cell["linked_to_boardbuilder_board_id"] }
               end
 
-              row = index / gs_board["columns"]
-              column = index % gs_board["columns"]
-              if row < obf_in_json["grid"]["rows"] and column < obf_in_json["grid"]["columns"]
-                obf_in_json["grid"]["order"][row][column] = button_id
-                obf_in_json["buttons"] << button
-              end
+              obf["grid"]["order"][row][column] = button_id
+              obf["buttons"] << button
             end
-            obf_in_json
+
+            obf
           end
 
-          def self.generate_unique_id(prefix, postfix = "0")
-            "#{prefix}-#{SecureRandom.random_number(10**10)}#{postfix}"
+          # ID generators
+          # Spec: IDs must be strings and unique within the .obz package.
+          # Combining a random hex segment with the GS record id guarantees both.
+
+          def self.generate_board_id(gs_id)
+            "board-#{SecureRandom.hex(6)}-#{gs_id}"
+          end
+
+          def self.generate_button_id(gs_cell_id)
+            "btn-#{SecureRandom.hex(4)}-#{gs_cell_id}"
+          end
+
+          def self.generate_image_id(gs_cell_id)
+            "img-#{SecureRandom.hex(4)}-#{gs_cell_id}"
           end
 
           private_class_method :transform_board_to_obf
-          private_class_method :generate_unique_id
+          private_class_method :generate_board_id
+          private_class_method :generate_button_id
+          private_class_method :generate_image_id
         end
     end
 end

--- a/app/api/board_builder/v1/board_sets.rb
+++ b/app/api/board_builder/v1/board_sets.rb
@@ -101,6 +101,21 @@ module BoardBuilder::V1
           present boardset, with: Entities::BoardSet, expand: params[:expand], readonly: !(can? :manage, boardset), boards_with_cells: boardset.boards
         end
 
+        desc 'Returns a specific BoardSet belonging to the current user in OBZ format',
+             success: Entities::BoardSetObz,
+             is_array: false
+        params do
+          requires :id, type: Integer, desc: 'BoardSet ID'
+        end
+        oauth2 'boardset:read'
+        get :obz do
+          board_set = Boardbuilder::BoardSet.accessible_by(current_ability)
+                                            .includes(boards: :cells)
+                                            .find(params[:id])
+          board_set.download_count += 1
+          board_set.save!
+          present board_set, with: Entities::BoardSetObz
+        end
 
         desc 'Updates a BoardSet belonging to the current user',
              success: Entities::BoardSet,
@@ -199,6 +214,7 @@ module BoardBuilder::V1
         board_set = save_board_set(filtered_params)
         present board_set, with: Entities::BoardSet, expand: 'boards'
       end
+
     end
   end
 end

--- a/app/api/board_builder/v1/board_sets.rb
+++ b/app/api/board_builder/v1/board_sets.rb
@@ -53,6 +53,7 @@ module BoardBuilder::V1
            is_array: false
       params do
         requires :id, type: Integer, desc: 'ID of the BoardSet'
+        optional :embed_images, type: Boolean, default: false, desc: 'When true, images are downloaded and embedded in the archive instead of referenced by URL. Produces a fully self-contained OBZ file.'
       end
       get 'public/obz/:id' do
         board_set = Boardbuilder::BoardSet.includes(boards: :cells).where(id: params[:id], public: true).first
@@ -60,7 +61,7 @@ module BoardBuilder::V1
           board_set.download_count += 1
           board_set.save!
         end
-        present board_set, with: Entities::BoardSetObz
+        present board_set, with: Entities::BoardSetObz, embed_images: params[:embed_images]
       end
 
       desc 'Returns featured BoardSets',
@@ -106,6 +107,7 @@ module BoardBuilder::V1
              is_array: false
         params do
           requires :id, type: Integer, desc: 'BoardSet ID'
+          optional :embed_images, type: Boolean, default: false, desc: 'When true, images are downloaded and embedded in the archive instead of referenced by URL. Produces a fully self-contained OBZ file.'
         end
         oauth2 'boardset:read'
         get :obz do
@@ -114,7 +116,7 @@ module BoardBuilder::V1
                                             .find(params[:id])
           board_set.download_count += 1
           board_set.save!
-          present board_set, with: Entities::BoardSetObz
+          present board_set, with: Entities::BoardSetObz, embed_images: params[:embed_images]
         end
 
         desc 'Updates a BoardSet belonging to the current user',

--- a/app/api/board_builder/v1/entities/board_set_obz.rb
+++ b/app/api/board_builder/v1/entities/board_set_obz.rb
@@ -21,9 +21,9 @@ module BoardBuilder
       board_set.thumbnail&.file&.url
     end
 
-    expose :obz_file_map do |board_set|
+    expose :obz_file_map do |board_set, options|
       boards = board_set.boards.sort_by{|e| e[:index]}
-      BoardBuilder::Util::BoardsToObz.boards_to_obz_file_map(boards)
+      BoardBuilder::Util::BoardsToObz.boards_to_obz_file_map(boards, embed_images: options[:embed_images] || false)
     end
 
     expose :owner do |board_set|


### PR DESCRIPTION
I used Claude Code (Sonnet 4.6) to fix and improve the OBZ creation according to the specification (https://www.openboardformat.org/docs).

- Fixes mainly concern the usage of filepaths instead of file IDs in mapping objects.
- A new option is added to embed images directly in the OBZ instead of giving the URL. This allows to get a full self-contained boardset.

To get more details, read each commit message.